### PR TITLE
Улучшение расчёта высоты выпадающего списка в селекте

### DIFF
--- a/src/script/_select.js
+++ b/src/script/_select.js
@@ -276,8 +276,8 @@ var selectboxOutput = function()
 			opacity: 0
 		} );
 
-		var selectHeight = selectbox.outerHeight( ),
-			searchHeight = search.outerHeight( ),
+		var selectHeight = selectbox.outerHeight( true ),
+			searchHeight = search.parent( ).outerHeight( true ),
 			isMaxHeight = ul.css( 'max-height' ),
 			liSelected = li.filter( '.selected' ),
 			position = dropdown.css( 'top' );


### PR DESCRIPTION
Пример бага http://codepen.io/pafnuty/pen/gaXENy высота выпадающего списка больше, чем нужно т.к. к форме поиска и самому выпадающему списку добавлены отступы.
`search.parent()` - обращаемся к родителю инпута для корректности расчёта его высоты.
`.outerHeight(true)` - учитываем margin при расчёте высоты.

Этот пулреквест в оригинальном репе: https://github.com/Dimox/jQueryFormStyler/pull/93